### PR TITLE
Revamp chapter 1 examples and navigation UX

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -185,8 +185,8 @@
 						<p class="mb-6 text-red-700">
 							{error}
 						</p>
-						<button
-							on:click={resetAnalysis}
+                                                <button
+                                                        onclick={resetAnalysis}
 							class="transform rounded-xl bg-gradient-to-r from-primary-500 to-primary-600
                                    px-6 py-3 font-medium text-white
                                    shadow-lg transition-all duration-200 hover:scale-105
@@ -211,8 +211,8 @@
 						>
 						Analytics Dashboard
 					</h2>
-					<button
-						on:click={resetAnalysis}
+                                        <button
+                                                onclick={resetAnalysis}
 						class="flex items-center gap-2 rounded-lg
                                bg-secondary-200 px-4 py-2 font-medium text-secondary-800
                                transition-all duration-200 hover:bg-secondary-300"

--- a/src/lib/components/FileUpload.svelte
+++ b/src/lib/components/FileUpload.svelte
@@ -56,7 +56,7 @@
 		type="file"
 		accept=".txt,.log"
 		bind:this={fileInput}
-		on:change={handleFileSelect}
+                onchange={handleFileSelect}
 		class="hidden"
 	/>
 
@@ -65,13 +65,13 @@
                {isDragOver
 			? 'scale-105 border-primary-400 bg-primary-50/20'
 			: 'border-primary-300/50 hover:border-primary-400/70 hover:bg-primary-50/10'}"
-		on:dragover={handleDragOver}
-		on:dragleave={handleDragLeave}
-		on:drop={handleDrop}
+                ondragover={handleDragOver}
+                ondragleave={handleDragLeave}
+                ondrop={handleDrop}
 		role="button"
 		tabindex="0"
-		on:click={openFileDialog}
-		on:keydown={(e) => e.key === 'Enter' && openFileDialog()}
+                onclick={openFileDialog}
+                onkeydown={(e) => e.key === 'Enter' && openFileDialog()}
 	>
 		<div class="p-12 text-center">
 			{#if fileName}
@@ -86,8 +86,8 @@
 					<p class="font-medium text-primary-600">{fileName}</p>
 				</div>
 
-				<button
-					on:click|stopPropagation={openFileDialog}
+                                <button
+                                        onclick|stopPropagation={openFileDialog}
 					class="transform rounded-xl bg-gradient-to-r from-primary-500 to-primary-600
                            px-6 py-3 font-medium text-white shadow-lg
                            transition-all duration-200 hover:scale-105 hover:from-primary-600 hover:to-primary-700 hover:shadow-xl"

--- a/src/lib/components/FileUpload.svelte
+++ b/src/lib/components/FileUpload.svelte
@@ -46,9 +46,14 @@
 		reader.readAsText(file);
 	}
 
-	function openFileDialog() {
-		fileInput.click();
-	}
+        function openFileDialog() {
+                fileInput.click();
+        }
+
+        function triggerFileDialog(event) {
+                event.stopPropagation();
+                openFileDialog();
+        }
 </script>
 
 <div class="relative">
@@ -87,7 +92,7 @@
 				</div>
 
                                 <button
-                                        onclick|stopPropagation={openFileDialog}
+                                        onclick={triggerFileDialog}
 					class="transform rounded-xl bg-gradient-to-r from-primary-500 to-primary-600
                            px-6 py-3 font-medium text-white shadow-lg
                            transition-all duration-200 hover:scale-105 hover:from-primary-600 hover:to-primary-700 hover:shadow-xl"

--- a/src/lib/components/book/examples/Avatar.svelte
+++ b/src/lib/components/book/examples/Avatar.svelte
@@ -59,13 +59,13 @@
 		class={imageClasses}
 		onload={handleImageLoad}
 		onerror={handleImageError}
-		onclick={() => onclick(user)}
+                on:click={() => onclick(user)}
 		{...restProps}
 	/>
 {:else}
 	<div
 		class={fallbackClasses}
-		onclick={() => onclick(user)}
+                on:click={() => onclick(user)}
 		{...restProps}
 	>
 		{initials}

--- a/src/lib/components/book/examples/Avatar.svelte
+++ b/src/lib/components/book/examples/Avatar.svelte
@@ -59,13 +59,13 @@
 		class={imageClasses}
 		onload={handleImageLoad}
 		onerror={handleImageError}
-                on:click={() => onclick(user)}
+                onclick={() => onclick(user)}
 		{...restProps}
 	/>
 {:else}
 	<div
 		class={fallbackClasses}
-                on:click={() => onclick(user)}
+                onclick={() => onclick(user)}
 		{...restProps}
 	>
 		{initials}

--- a/src/lib/components/book/examples/BadComponent.svelte
+++ b/src/lib/components/book/examples/BadComponent.svelte
@@ -81,21 +81,21 @@
 	{#if showActions}
 		<div class="actions">
 			{#if actionType === 'full'}
-                                <button type="button" on:click={() => handleAction('edit')} disabled={isLoading}>
+                                <button type="button" onclick={() => handleAction('edit')} disabled={isLoading}>
                                         {isLoading ? 'Loading...' : 'Edit'}
                                 </button>
-                                <button type="button" on:click={() => handleAction('delete')} disabled={isLoading}>
+                                <button type="button" onclick={() => handleAction('delete')} disabled={isLoading}>
                                         {isLoading ? 'Loading...' : 'Delete'}
                                 </button>
-                                <button type="button" on:click={() => handleAction('view')} disabled={isLoading}>
+                                <button type="button" onclick={() => handleAction('view')} disabled={isLoading}>
                                         {isLoading ? 'Loading...' : 'View'}
                                 </button>
                         {:else if actionType === 'edit-only'}
-                                <button type="button" on:click={() => handleAction('edit')} disabled={isLoading}>
+                                <button type="button" onclick={() => handleAction('edit')} disabled={isLoading}>
                                         {isLoading ? 'Loading...' : 'Edit'}
                                 </button>
                         {:else if actionType === 'view-only'}
-                                <button type="button" on:click={() => handleAction('view')} disabled={isLoading}>
+                                <button type="button" onclick={() => handleAction('view')} disabled={isLoading}>
                                         {isLoading ? 'Loading...' : 'View'}
                                 </button>
 			{/if}

--- a/src/lib/components/book/examples/BadComponent.svelte
+++ b/src/lib/components/book/examples/BadComponent.svelte
@@ -50,12 +50,12 @@
 
 <!-- Too many conditional renders -->
 <div class="user-card" style={cardStyle}>
-	{#if showAvatar}
-		<img
-			src={userData?.avatar || '/default-avatar.png'}
-			alt={userData?.name}
-			style="width: {avatarSize || 48}px; height: {avatarSize || 48}px;"
-		/>
+        {#if showAvatar}
+                <img
+                        src={userData?.avatar || '/default-avatar.png'}
+                        alt={userData?.name}
+                        style={`width: ${(avatarSize || 48)}px; height: ${(avatarSize || 48)}px;`}
+                />
 	{/if}
 
 	<div class="user-info">
@@ -81,23 +81,23 @@
 	{#if showActions}
 		<div class="actions">
 			{#if actionType === 'full'}
-				<button onclick={() => handleAction('edit')} disabled={isLoading}>
-					{isLoading ? 'Loading...' : 'Edit'}
-				</button>
-				<button onclick={() => handleAction('delete')} disabled={isLoading}>
-					{isLoading ? 'Loading...' : 'Delete'}
-				</button>
-				<button onclick={() => handleAction('view')} disabled={isLoading}>
-					{isLoading ? 'Loading...' : 'View'}
-				</button>
-			{:else if actionType === 'edit-only'}
-				<button onclick={() => handleAction('edit')} disabled={isLoading}>
-					{isLoading ? 'Loading...' : 'Edit'}
-				</button>
-			{:else if actionType === 'view-only'}
-				<button onclick={() => handleAction('view')} disabled={isLoading}>
-					{isLoading ? 'Loading...' : 'View'}
-				</button>
+                                <button type="button" on:click={() => handleAction('edit')} disabled={isLoading}>
+                                        {isLoading ? 'Loading...' : 'Edit'}
+                                </button>
+                                <button type="button" on:click={() => handleAction('delete')} disabled={isLoading}>
+                                        {isLoading ? 'Loading...' : 'Delete'}
+                                </button>
+                                <button type="button" on:click={() => handleAction('view')} disabled={isLoading}>
+                                        {isLoading ? 'Loading...' : 'View'}
+                                </button>
+                        {:else if actionType === 'edit-only'}
+                                <button type="button" on:click={() => handleAction('edit')} disabled={isLoading}>
+                                        {isLoading ? 'Loading...' : 'Edit'}
+                                </button>
+                        {:else if actionType === 'view-only'}
+                                <button type="button" on:click={() => handleAction('view')} disabled={isLoading}>
+                                        {isLoading ? 'Loading...' : 'View'}
+                                </button>
 			{/if}
 		</div>
 	{/if}

--- a/src/lib/components/book/examples/ComponentComparison.svelte
+++ b/src/lib/components/book/examples/ComponentComparison.svelte
@@ -1,118 +1,242 @@
 <script>
-	import BadComponent from './BadComponent.svelte';
-	import GoodUserCard from './GoodUserCard.svelte';
+  import BadComponent from './BadComponent.svelte';
+  import GoodUserCard from './GoodUserCard.svelte';
 
-	// Sample user data
-	const sampleUser = {
-		name: 'Jane Smith',
-		email: 'jane@example.com',
-		phone: '+1 (555) 123-4567',
-		role: 'admin',
-		avatar: 'https://images.unsplash.com/photo-1494790108755-2616b612b47c?w=150&h=150&fit=crop&crop=face'
-	};
+  const sampleUser = {
+    name: 'Jane Smith',
+    email: 'jane@example.com',
+    phone: '+1 (555) 123-4567',
+    role: 'admin',
+    avatar: 'https://images.unsplash.com/photo-1494790108755-2616b612b47c?w=150&h=150&fit=crop&crop=face'
+  };
 
-	// Example actions for the good component
-	const userActions = [
-		{
-			label: 'Edit',
-			icon: '✏️',
-			handler: (user) => {
-				alert(`Editing ${user.name}`);
-			}
-		},
-		{
-			label: 'Delete',
-			icon: '🗑️',
-			handler: (user) => {
-				alert(`Deleting ${user.name}`);
-			}
-		}
-	];
+  const pause = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-	let selectedDemo = $state('bad');
+  const userActions = [
+    {
+      label: 'Edit',
+      icon: '✏️',
+      handler: async (user) => {
+        await pause(450);
+        alert(`Editing ${user.name}`);
+      }
+    },
+    {
+      label: 'Delete',
+      icon: '🗑️',
+      handler: async (user) => {
+        await pause(450);
+        alert(`Deleting ${user.name}`);
+      }
+    }
+  ];
+
+  const demos = {
+    bad: {
+      id: 'bad',
+      label: 'Poor Architecture',
+      emoji: '❌',
+      summary:
+        'An overloaded component that tries to do everything at once. Notice how the public API becomes unpredictable and the UI logic leaks everywhere.',
+      points: [
+        'Too many props (16+ props make the component impossible to memorise)',
+        'Inline styling and conditional logic tightly coupled to the view',
+        'Business logic, UI state, and actions all live in the same component'
+      ],
+      metrics: [
+        {
+          label: 'Props surface',
+          value: '16 props',
+          helper: 'Every scenario is toggled with a new prop'
+        },
+        {
+          label: 'Responsibilities',
+          value: 'UI + state + actions',
+          helper: 'Difficult to isolate behaviour for testing'
+        },
+        {
+          label: 'Reusability',
+          value: 'Low',
+          helper: 'Component knows about specific layouts and actions'
+        }
+      ]
+    },
+    good: {
+      id: 'good',
+      label: 'Good Architecture',
+      emoji: '✅',
+      summary:
+        'A focused user card that composes smaller building blocks. The public API stays small while offering powerful extension points.',
+      points: [
+        'Intentional props (user, variant, size, actions) communicate the contract clearly',
+        'Dedicated components for avatar, badge, and actions keep concerns separate',
+        'Snippets and action handlers allow extension without modifying the card'
+      ],
+      metrics: [
+        {
+          label: 'Props surface',
+          value: '4 core props',
+          helper: 'Clear contract: user, variant, size, actions'
+        },
+        {
+          label: 'Responsibilities',
+          value: 'Composition only',
+          helper: 'State and data stay with their owners'
+        },
+        {
+          label: 'Extensibility',
+          value: 'High',
+          helper: 'Snippets expose custom content while actions encapsulate behaviour'
+        }
+      ]
+    }
+  };
+
+  const demoList = Object.values(demos);
+  let selectedDemo = $state('bad');
+  const activeDemo = $derived(() => demos[selectedDemo] ?? demos.bad);
+
+  function selectDemo(id) {
+    selectedDemo = id;
+  }
 </script>
 
-<div class="component-comparison">
-	<div class="mb-6">
-		<div class="flex gap-4 mb-4">
-			<button
-				onclick={() => selectedDemo = 'bad'}
-				class="px-4 py-2 rounded-lg transition-colors
-					{selectedDemo === 'bad'
-						? 'bg-red-100 text-red-700 border border-red-300'
-						: 'bg-gray-100 text-gray-700 hover:bg-gray-200'}"
-			>
-				❌ Poor Architecture
-			</button>
-			<button
-				onclick={() => selectedDemo = 'good'}
-				class="px-4 py-2 rounded-lg transition-colors
-					{selectedDemo === 'good'
-						? 'bg-green-100 text-green-700 border border-green-300'
-						: 'bg-gray-100 text-gray-700 hover:bg-gray-200'}"
-			>
-				✅ Good Architecture
-			</button>
-		</div>
+<div class="component-comparison space-y-8">
+  <div class="space-y-6">
+    <div class="space-y-3">
+      <span class="text-xs font-semibold uppercase tracking-[0.35em] text-blue-600">Live comparison</span>
+      <h3 class="text-2xl font-semibold text-gray-900">Good architecture feels different in use</h3>
+      <p class="max-w-3xl text-sm text-gray-600 md:text-base">
+        The same requirement implemented two ways. Switch between them to feel how API design, composition, and extensibility
+        change the developer experience.
+      </p>
+    </div>
 
-		{#if selectedDemo === 'bad'}
-			<div class="p-4 bg-red-50 border border-red-200 rounded-lg">
-				<h4 class="font-semibold text-red-800 mb-2">Problems with this approach:</h4>
-				<ul class="text-sm text-red-700 space-y-1">
-					<li>• Too many props (16+ props make it hard to use)</li>
-					<li>• Mixed responsibilities (UI, data, actions, styling)</li>
-					<li>• Inline styles make it unmaintainable</li>
-					<li>• Complex conditional logic</li>
-					<li>• Hard to test individual features</li>
-					<li>• Difficult to extend or modify</li>
-				</ul>
-			</div>
-		{:else}
-			<div class="p-4 bg-green-50 border border-green-200 rounded-lg">
-				<h4 class="font-semibold text-green-800 mb-2">Benefits of this approach:</h4>
-				<ul class="text-sm text-green-700 space-y-1">
-					<li>• Clear, focused props (user, variant, size, actions)</li>
-					<li>• Single responsibility per component</li>
-					<li>• Composable and reusable</li>
-					<li>• Easy to test each piece independently</li>
-					<li>• Consistent styling through design system</li>
-					<li>• Easy to extend with new features</li>
-				</ul>
-			</div>
-		{/if}
-	</div>
+    <div class="inline-flex w-fit items-center gap-2 rounded-full bg-gray-100 p-1 shadow-inner">
+      {#each demoList as demo}
+        <button
+          type="button"
+          class={
+            selectedDemo === demo.id
+              ? 'inline-flex items-center gap-2 rounded-full bg-white px-4 py-2 text-sm font-medium text-gray-900 shadow apple-transition'
+              : 'inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm text-gray-600 hover:text-gray-900 apple-transition'
+          }
+          aria-pressed={selectedDemo === demo.id}
+          on:click={() => selectDemo(demo.id)}
+        >
+          <span class="text-base">{demo.emoji}</span>
+          <span>{demo.label}</span>
+        </button>
+      {/each}
+    </div>
+  </div>
 
-	<div class="demo-area bg-gray-50 p-8 rounded-lg border border-gray-200">
-		{#if selectedDemo === 'bad'}
-			<BadComponent
-				userType="admin"
-				userData={sampleUser}
-				showAvatar={true}
-				avatarSize={48}
-				showEmail={true}
-				showPhone={false}
-				showActions={true}
-				actionType="full"
-				onEdit={(user) => alert(`Editing ${user.name}`)}
-				onDelete={(user) => alert(`Deleting ${user.name}`)}
-				onView={(user) => alert(`Viewing ${user.name}`)}
-				backgroundColor="#ffffff"
-				textColor="#000000"
-				borderStyle="1px solid #e5e7eb"
-				padding="1.5rem"
-			/>
-		{:else}
-			<GoodUserCard
-				user={sampleUser}
-				variant="default"
-				size="md"
-				actions={userActions}
-				onclick={(user) => alert(`Clicked ${user.name}`)}
-			>
-				{#snippet children({ user })}
-					<p class="text-xs text-gray-500">Last seen: 2 hours ago</p>
-				{/snippet}
-			</GoodUserCard>
-		{/if}
-	</div>
+  <div
+    class={
+      selectedDemo === 'bad'
+        ? 'rounded-2xl border border-red-200 bg-red-50 p-6 shadow-sm'
+        : 'rounded-2xl border border-green-200 bg-green-50 p-6 shadow-sm'
+    }
+  >
+    <h4 class={selectedDemo === 'bad' ? 'text-red-800 font-semibold mb-3' : 'text-green-800 font-semibold mb-3'}>
+      {activeDemo.label} patterns
+    </h4>
+    <p class="mb-4 max-w-3xl text-sm text-gray-700 md:text-base">{activeDemo.summary}</p>
+    <ul class={selectedDemo === 'bad' ? 'space-y-2 text-sm text-red-700 md:text-base' : 'space-y-2 text-sm text-green-700 md:text-base'}>
+      {#each activeDemo.points as point}
+        <li class="flex gap-2">
+          <span>{selectedDemo === 'bad' ? '⚠️' : '✨'}</span>
+          <span class="flex-1 leading-relaxed">{point}</span>
+        </li>
+      {/each}
+    </ul>
+  </div>
+
+  <div class="grid gap-6 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
+    <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+      <div class="mb-4 flex items-center justify-between">
+        <h5 class="text-xs font-semibold uppercase tracking-[0.25em] text-gray-500">Example component</h5>
+        <span
+          class={
+            selectedDemo === 'bad'
+              ? 'rounded-full bg-red-100 px-3 py-1 text-xs font-medium text-red-700'
+              : 'rounded-full bg-green-100 px-3 py-1 text-xs font-medium text-green-700'
+          }
+        >
+          {activeDemo.label}
+        </span>
+      </div>
+      <div class="rounded-xl border border-dashed border-gray-200 bg-gray-50 p-6">
+        {#if selectedDemo === 'bad'}
+          <BadComponent
+            userType="admin"
+            userData={sampleUser}
+            showAvatar={true}
+            avatarSize={48}
+            showEmail={true}
+            showPhone={false}
+            showActions={true}
+            actionType="full"
+            onEdit={(user) => alert(`Editing ${user.name}`)}
+            onDelete={(user) => alert(`Deleting ${user.name}`)}
+            onView={(user) => alert(`Viewing ${user.name}`)}
+            backgroundColor="#ffffff"
+            textColor="#000000"
+            borderStyle="1px solid #e5e7eb"
+            padding="1.5rem"
+          />
+        {:else}
+          <GoodUserCard
+            user={sampleUser}
+            variant="default"
+            size="md"
+            actions={userActions}
+            onclick={(user) => alert(`Clicked ${user.name}`)}
+          >
+            {#snippet children({ user })}
+              <p class="text-xs text-gray-500">Last seen: 2 hours ago</p>
+            {/snippet}
+          </GoodUserCard>
+        {/if}
+      </div>
+    </div>
+    <div class="space-y-4">
+      <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+        <h5 class="text-xs font-semibold uppercase tracking-[0.25em] text-gray-500">Architecture metrics</h5>
+        <p class="mt-2 text-sm text-gray-600">
+          Compare how each version feels when you integrate it into a real screen and maintain it over time.
+        </p>
+        <div class="mt-5 grid gap-4">
+          {#each activeDemo.metrics as metric}
+            <div
+              class={
+                selectedDemo === 'bad'
+                  ? 'rounded-xl border border-red-100 bg-red-50 p-4'
+                  : 'rounded-xl border border-green-100 bg-green-50 p-4'
+              }
+            >
+              <div class="text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">{metric.label}</div>
+              <div
+                class={
+                  selectedDemo === 'bad'
+                    ? 'mt-1 text-base font-semibold text-red-700'
+                    : 'mt-1 text-base font-semibold text-green-700'
+                }
+              >
+                {metric.value}
+              </div>
+              <p class="mt-1 text-sm text-gray-600">{metric.helper}</p>
+            </div>
+          {/each}
+        </div>
+      </div>
+      <div class="rounded-2xl border border-blue-100 bg-blue-50 p-6 shadow-inner">
+        <h5 class="text-xs font-semibold uppercase tracking-[0.25em] text-blue-900">What to try next</h5>
+        <p class="mt-2 text-sm text-blue-900/80">
+          Inspect the props available on each component and imagine how you would add a "Suspend user" action. The well-architected
+          version gives you extension points without modifying the base component.
+        </p>
+      </div>
+    </div>
+  </div>
 </div>

--- a/src/lib/components/book/examples/ComponentComparison.svelte
+++ b/src/lib/components/book/examples/ComponentComparison.svelte
@@ -122,7 +122,7 @@
               : 'inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm text-gray-600 hover:text-gray-900 apple-transition'
           }
           aria-pressed={selectedDemo === demo.id}
-          on:click={() => selectDemo(demo.id)}
+          onclick={() => selectDemo(demo.id)}
         >
           <span class="text-base">{demo.emoji}</span>
           <span>{demo.label}</span>

--- a/src/lib/components/book/examples/GoodUserCard.svelte
+++ b/src/lib/components/book/examples/GoodUserCard.svelte
@@ -68,7 +68,7 @@
 {/snippet}
 
 {#if onclick}
-  <button type="button" class={cardClasses} on:click={handleClick} {...restProps}>
+  <button type="button" class={cardClasses} onclick={handleClick} {...restProps}>
     {@render cardContent()}
   </button>
 {:else}

--- a/src/lib/components/book/examples/GoodUserCard.svelte
+++ b/src/lib/components/book/examples/GoodUserCard.svelte
@@ -1,114 +1,88 @@
 <script>
-	// Well-architected component with clear responsibilities
-	import Avatar from './Avatar.svelte';
-	import UserBadge from './UserBadge.svelte';
-	import ActionButtons from './ActionButtons.svelte';
+  import Avatar from './Avatar.svelte';
+  import UserBadge from './UserBadge.svelte';
+  import ActionButtons from './ActionButtons.svelte';
 
-	let {
-		user,
-		variant = 'default',
-		size = 'md',
-		children,
-		actions,
-		onclick = () => {},
-		...restProps
-	} = $props();
+  let {
+    user,
+    variant = 'default',
+    size = 'md',
+    children,
+    actions,
+    onclick = undefined,
+    ...restProps
+  } = $props();
 
-	// Single responsibility: UI composition and layout
-	const cardClasses = $derived(() => {
-		const base = 'user-card rounded-lg border transition-all duration-200';
-		const variants = {
-			default: 'border-gray-200 bg-white hover:shadow-md',
-			compact: 'border-gray-200 bg-white p-4',
-			highlighted: 'border-blue-200 bg-blue-50 hover:bg-blue-100'
-		};
-		const sizes = {
-			sm: 'p-4',
-			md: 'p-6',
-			lg: 'p-8'
-		};
-		return `${base} ${variants[variant]} ${sizes[size]}`;
-	});
+  const cardClasses = $derived(() => {
+    const base =
+      'user-card rounded-lg border transition-all duration-200 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2';
+    const variants = {
+      default: 'border-gray-200 bg-white hover:shadow-md',
+      compact: 'border-gray-200 bg-white p-4',
+      highlighted: 'border-blue-200 bg-blue-50 hover:bg-blue-100'
+    };
+    const sizes = {
+      sm: 'p-4',
+      md: 'p-6',
+      lg: 'p-8'
+    };
 
-	function handleClick() {
-		onclick(user);
-	}
+    const variantClasses = variants[variant] ?? variants.default;
+    const sizeClasses = sizes[size] ?? sizes.md;
+
+    return `${base} ${variantClasses} ${sizeClasses}`;
+  });
+
+  function handleClick() {
+    if (onclick) {
+      onclick(user);
+    }
+  }
 </script>
 
+{#snippet cardContent()}
+  <div class="flex items-center gap-4">
+    <Avatar user={user} size={size} />
+
+    <div class="min-w-0 flex-1">
+      <div class="mb-1 flex items-center gap-2">
+        <h3 class="truncate font-semibold text-gray-900">{user.name}</h3>
+        <UserBadge role={user.role} />
+      </div>
+
+      {#if user.email}
+        <p class="truncate text-sm text-gray-600">{user.email}</p>
+      {/if}
+
+      {#if children}
+        <div class="mt-2">
+          {@render children({ user })}
+        </div>
+      {/if}
+    </div>
+
+    {#if actions}
+      <ActionButtons {user} {actions} />
+    {/if}
+  </div>
+{/snippet}
+
 {#if onclick}
-<button
-	class={cardClasses}
-	onclick={handleClick}
-	{...restProps}
->
-	<div class="flex items-center gap-4">
-		<Avatar user={user} size={size} />
-
-		<div class="flex-1 min-w-0">
-			<div class="flex items-center gap-2 mb-1">
-				<h3 class="font-semibold text-gray-900 truncate">{user.name}</h3>
-				<UserBadge role={user.role} />
-			</div>
-
-			{#if user.email}
-				<p class="text-sm text-gray-600 truncate">{user.email}</p>
-			{/if}
-
-			{#if children}
-				<div class="mt-2">
-					{@render children({ user })}
-				</div>
-			{/if}
-		</div>
-
-		{#if actions}
-			<ActionButtons {user} {actions} />
-		{/if}
-	</div>
-</button>
+  <button type="button" class={cardClasses} on:click={handleClick} {...restProps}>
+    {@render cardContent()}
+  </button>
 {:else}
-<div
-	class={cardClasses}
-	{...restProps}
->
-	<div class="flex items-center gap-4">
-		<Avatar user={user} size={size} />
-
-		<div class="flex-1 min-w-0">
-			<div class="flex items-center gap-2 mb-1">
-				<h3 class="font-semibold text-gray-900 truncate">{user.name}</h3>
-				<UserBadge role={user.role} />
-			</div>
-
-			{#if user.email}
-				<p class="text-sm text-gray-600 truncate">{user.email}</p>
-			{/if}
-
-			{#if children}
-				<div class="mt-2">
-					{@render children({ user })}
-				</div>
-			{/if}
-		</div>
-
-		{#if actions}
-			<ActionButtons {user} {actions} />
-		{/if}
-	</div>
-</div>
+  <div class={cardClasses} {...restProps}>
+    {@render cardContent()}
+  </div>
 {/if}
 
 <style>
-	.user-card {
-		cursor: default;
-	}
+  .user-card {
+    cursor: default;
+  }
 
-	.user-card[role="button"] {
-		cursor: pointer;
-	}
-
-	.user-card[role="button"]:focus-visible {
-		outline: 2px solid #3b82f6;
-		outline-offset: 2px;
-	}
+  .user-card:focus-visible {
+    outline: none;
+  }
 </style>

--- a/src/lib/components/ui/Button.svelte
+++ b/src/lib/components/ui/Button.svelte
@@ -44,7 +44,7 @@
 	class={buttonClasses}
 	{type}
 	{disabled}
-	onclick={handleClick}
+        on:click={handleClick}
 	{...restProps}
 >
 	{#if loading}

--- a/src/lib/components/ui/Button.svelte
+++ b/src/lib/components/ui/Button.svelte
@@ -44,7 +44,7 @@
 	class={buttonClasses}
 	{type}
 	{disabled}
-        on:click={handleClick}
+        onclick={handleClick}
 	{...restProps}
 >
 	{#if loading}

--- a/src/lib/layouts/BookLayout.svelte
+++ b/src/lib/layouts/BookLayout.svelte
@@ -111,7 +111,7 @@
               <button
                 type="button"
                 class={topNavClasses(chapter)}
-                on:click={() => navigateToChapter(chapter)}
+                onclick={() => navigateToChapter(chapter)}
                 disabled={chapter.disabled}
                 aria-current={isActiveChapter(chapter) ? 'page' : undefined}
                 aria-disabled={chapter.disabled ? 'true' : undefined}
@@ -135,7 +135,7 @@
                   <button
                     type="button"
                     class={tableOfContentsClasses(chapter)}
-                    on:click={() => navigateToChapter(chapter)}
+                    onclick={() => navigateToChapter(chapter)}
                     disabled={chapter.disabled}
                     aria-current={isActiveChapter(chapter) ? 'page' : undefined}
                     aria-disabled={chapter.disabled ? 'true' : undefined}
@@ -190,7 +190,7 @@
                   <button
                     type="button"
                     class="flex items-center gap-2 rounded-xl bg-gray-100 px-6 py-3 transition-colors hover:bg-gray-200"
-                    on:click={() => navigateToChapter(prevChapter)}
+                    onclick={() => navigateToChapter(prevChapter)}
                   >
                     <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
@@ -208,7 +208,7 @@
                   <button
                     type="button"
                     class="flex items-center gap-2 rounded-xl bg-blue-500 px-6 py-3 text-white transition-colors hover:bg-blue-600"
-                    on:click={() => navigateToChapter(nextChapter)}
+                    onclick={() => navigateToChapter(nextChapter)}
                   >
                     <div class="text-right">
                       <div class="text-xs text-blue-100">Next</div>

--- a/src/lib/layouts/BookLayout.svelte
+++ b/src/lib/layouts/BookLayout.svelte
@@ -1,202 +1,229 @@
 <script>
-	import { page } from '$app/stores';
-	import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import { goto } from '$app/navigation';
 
-	let { children } = $props();
+  let { children } = $props();
 
-	// Book navigation structure
-	const bookChapters = [
-		{
-			id: 'chapter-1',
-			title: 'Component Architecture Fundamentals',
-			path: '/book/chapter-1'
-		},
-		{
-			id: 'chapter-2',
-			title: 'State Management Patterns',
-			path: '/book/chapter-2',
-			disabled: true
-		},
-		{
-			id: 'chapter-3',
-			title: 'Advanced Composition',
-			path: '/book/chapter-3',
-			disabled: true
-		}
-	];
+  const bookChapters = [
+    {
+      id: 'chapter-1',
+      title: 'Component Architecture Fundamentals',
+      path: '/book/chapter-1'
+    },
+    {
+      id: 'chapter-2',
+      title: 'State Management Patterns',
+      path: '/book/chapter-2',
+      disabled: true
+    },
+    {
+      id: 'chapter-3',
+      title: 'Advanced Composition',
+      path: '/book/chapter-3',
+      disabled: true
+    }
+  ];
 
-	const currentChapterIndex = $derived(() => {
-		return bookChapters.findIndex(chapter => $page.url.pathname === chapter.path);
-	});
+  const isActiveChapter = (chapter) => $page.url.pathname === chapter.path;
 
-	const currentChapter = $derived(() => {
-		return bookChapters[currentChapterIndex] || bookChapters[0];
-	});
+  const topNavClasses = (chapter) => {
+    const base =
+      'flex items-center gap-2 px-4 py-2 rounded-lg transition-all whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-1';
+    if (isActiveChapter(chapter)) {
+      return `${base} bg-blue-100 text-blue-700 font-medium`;
+    }
+    if (chapter.disabled) {
+      return `${base} text-gray-400 cursor-not-allowed`;
+    }
+    return `${base} text-gray-600 hover:bg-gray-100`;
+  };
 
-	const nextChapter = $derived(() => {
-		const nextIndex = currentChapterIndex + 1;
-		return nextIndex < bookChapters.length ? bookChapters[nextIndex] : null;
-	});
+  const topNavBadgeClasses = (chapter) => {
+    const base = 'w-6 h-6 rounded-full flex items-center justify-center text-xs';
+    if (isActiveChapter(chapter)) {
+      return `${base} bg-blue-200 text-blue-800`;
+    }
+    if (chapter.disabled) {
+      return `${base} bg-gray-200 text-gray-500`;
+    }
+    return `${base} bg-gray-200 text-gray-600`;
+  };
 
-	const prevChapter = $derived(() => {
-		const prevIndex = currentChapterIndex - 1;
-		return prevIndex >= 0 ? bookChapters[prevIndex] : null;
-	});
+  const tableOfContentsClasses = (chapter) => {
+    const base =
+      'w-full text-left px-3 py-2 rounded-lg transition-all text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-1';
+    if (isActiveChapter(chapter)) {
+      return `${base} bg-blue-50 text-blue-700 font-medium border-l-2 border-blue-500`;
+    }
+    if (chapter.disabled) {
+      return `${base} text-gray-400 cursor-not-allowed`;
+    }
+    return `${base} text-gray-600 hover:bg-gray-50`;
+  };
 
-	function navigateToChapter(chapter) {
-		if (!chapter.disabled) {
-			goto(chapter.path);
-		}
-	}
+  const currentChapterIndex = $derived(() => {
+    return bookChapters.findIndex((chapter) => $page.url.pathname === chapter.path);
+  });
+
+  const currentChapter = $derived(() => {
+    return bookChapters[currentChapterIndex] || bookChapters[0];
+  });
+
+  const nextChapter = $derived(() => {
+    const nextIndex = currentChapterIndex + 1;
+    return nextIndex < bookChapters.length ? bookChapters[nextIndex] : null;
+  });
+
+  const prevChapter = $derived(() => {
+    const prevIndex = currentChapterIndex - 1;
+    return prevIndex >= 0 ? bookChapters[prevIndex] : null;
+  });
+
+  function navigateToChapter(chapter) {
+    if (!chapter.disabled) {
+      goto(chapter.path);
+    }
+  }
 </script>
 
 <div class="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-	<div class="container mx-auto px-4 py-8">
-		<div class="max-w-6xl mx-auto">
-			<!-- Header -->
-			<header class="mb-8">
-				<div class="flex items-center justify-between mb-6">
-					<div>
-						<h1 class="text-3xl font-bold text-gray-900 mb-2">
-							Building Well-Architected Svelte Applications
-						</h1>
-						<p class="text-gray-600">A practical guide to component architecture and design patterns</p>
-					</div>
-					<a
-						href="/architecture"
-						class="text-blue-600 hover:text-blue-800 flex items-center gap-2"
-					>
-						← Back to Architecture Hub
-					</a>
-				</div>
+  <div class="container mx-auto px-4 py-8">
+    <div class="mx-auto max-w-6xl">
+      <!-- Header -->
+      <header class="mb-8">
+        <div class="mb-6 flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <p class="text-xs font-semibold uppercase tracking-[0.35em] text-blue-600">Architecture Playbook</p>
+            <h1 class="mb-2 text-3xl font-bold text-gray-900">
+              Building Well-Architected Svelte Applications
+            </h1>
+            <p class="text-gray-600">A practical guide to component architecture and design patterns</p>
+          </div>
+          <a href="/architecture" class="flex items-center gap-2 text-blue-600 transition hover:text-blue-800">
+            ← Back to Architecture Hub
+          </a>
+        </div>
 
-				<!-- Chapter Navigation -->
-				<nav class="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
-					<div class="flex items-center gap-4 overflow-x-auto">
-						{#each bookChapters as chapter, index}
-							<button
-								onclick={() => navigateToChapter(chapter)}
-								class="flex items-center gap-2 px-4 py-2 rounded-lg transition-all whitespace-nowrap
-									{$page.url.pathname === chapter.path
-										? 'bg-blue-100 text-blue-700 font-medium'
-										: chapter.disabled
-											? 'text-gray-400 cursor-not-allowed'
-											: 'text-gray-600 hover:bg-gray-100'}"
-								disabled={chapter.disabled}
-							>
-								<span class="w-6 h-6 rounded-full flex items-center justify-center text-xs
-									{$page.url.pathname === chapter.path
-										? 'bg-blue-200 text-blue-800'
-										: chapter.disabled
-											? 'bg-gray-200 text-gray-500'
-											: 'bg-gray-200 text-gray-600'}">
-									{index + 1}
-								</span>
-								{chapter.title}
-							</button>
-						{/each}
-					</div>
-				</nav>
-			</header>
+        <!-- Chapter Navigation -->
+        <nav class="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+          <div class="flex items-center gap-2 overflow-x-auto">
+            {#each bookChapters as chapter, index}
+              <button
+                type="button"
+                class={topNavClasses(chapter)}
+                on:click={() => navigateToChapter(chapter)}
+                disabled={chapter.disabled}
+                aria-current={isActiveChapter(chapter) ? 'page' : undefined}
+                aria-disabled={chapter.disabled ? 'true' : undefined}
+              >
+                <span class={topNavBadgeClasses(chapter)} aria-hidden="true">{index + 1}</span>
+                <span class="truncate">{chapter.title}</span>
+              </button>
+            {/each}
+          </div>
+        </nav>
+      </header>
 
-			<div class="grid grid-cols-12 gap-8">
-				<!-- Table of Contents -->
-				<aside class="col-span-3">
-					<div class="sticky top-8">
-						<div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-							<h3 class="font-semibold text-gray-900 mb-4">Table of Contents</h3>
-							<nav class="space-y-2">
-								{#each bookChapters as chapter, index}
-									<button
-										onclick={() => navigateToChapter(chapter)}
-										class="w-full text-left px-3 py-2 rounded-lg transition-all text-sm
-											{$page.url.pathname === chapter.path
-												? 'bg-blue-50 text-blue-700 font-medium border-l-2 border-blue-500'
-												: chapter.disabled
-													? 'text-gray-400 cursor-not-allowed'
-													: 'text-gray-600 hover:bg-gray-50'}"
-										disabled={chapter.disabled}
-									>
-										<div class="flex items-center gap-2">
-											<span class="text-xs">{index + 1}.</span>
-											{chapter.title}
-										</div>
-									</button>
-								{/each}
-							</nav>
+      <div class="grid grid-cols-12 gap-8">
+        <!-- Table of Contents -->
+        <aside class="col-span-3">
+          <div class="sticky top-8">
+            <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+              <h3 class="mb-4 font-semibold text-gray-900">Table of Contents</h3>
+              <nav class="space-y-2">
+                {#each bookChapters as chapter, index}
+                  <button
+                    type="button"
+                    class={tableOfContentsClasses(chapter)}
+                    on:click={() => navigateToChapter(chapter)}
+                    disabled={chapter.disabled}
+                    aria-current={isActiveChapter(chapter) ? 'page' : undefined}
+                    aria-disabled={chapter.disabled ? 'true' : undefined}
+                  >
+                    <div class="flex items-center gap-2">
+                      <span class="text-xs">{index + 1}.</span>
+                      <span class="truncate">{chapter.title}</span>
+                    </div>
+                  </button>
+                {/each}
+              </nav>
 
-							<!-- Reading Progress -->
-							<div class="mt-6 pt-6 border-t border-gray-200">
-								<div class="flex items-center justify-between mb-2">
-									<span class="text-sm text-gray-600">Progress</span>
-									<span class="text-sm font-medium text-gray-900">
-										{Math.round(((currentChapterIndex + 1) / bookChapters.length) * 100)}%
-									</span>
-								</div>
-								<div class="w-full bg-gray-200 rounded-full h-2">
-									<div
-										class="bg-blue-500 h-2 rounded-full transition-all duration-300"
-										style="width: {((currentChapterIndex + 1) / bookChapters.length) * 100}%"
-									></div>
-								</div>
-							</div>
-						</div>
-					</div>
-				</aside>
+              <!-- Reading Progress -->
+              <div class="mt-6 border-t border-gray-200 pt-6">
+                <div class="mb-2 flex items-center justify-between">
+                  <span class="text-sm text-gray-600">Progress</span>
+                  <span class="text-sm font-medium text-gray-900">
+                    {Math.round(((currentChapterIndex + 1) / bookChapters.length) * 100)}%
+                  </span>
+                </div>
+                <div class="h-2 w-full rounded-full bg-gray-200" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow={Math.round(((currentChapterIndex + 1) / bookChapters.length) * 100)}>
+                  <div
+                    class="h-2 rounded-full bg-blue-500 transition-all duration-300"
+                    style={`width: ${((currentChapterIndex + 1) / bookChapters.length) * 100}%`}
+                  ></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </aside>
 
-				<!-- Main Content -->
-				<main class="col-span-9">
-					<article class="bg-white rounded-xl shadow-sm border border-gray-200 p-8">
-						<div class="prose prose-lg max-w-none
-							prose-headings:text-gray-900
-							prose-p:text-gray-700 prose-p:leading-relaxed
-							prose-strong:text-gray-900
-							prose-code:bg-gray-100 prose-code:px-2 prose-code:py-1 prose-code:rounded prose-code:text-sm
-							prose-pre:bg-gray-900 prose-pre:text-gray-100
-							prose-blockquote:border-l-blue-500 prose-blockquote:bg-blue-50 prose-blockquote:p-4
-							prose-ul:text-gray-700 prose-ol:text-gray-700">
-							{@render children()}
-						</div>
+        <!-- Main Content -->
+        <main class="col-span-9">
+          <article class="rounded-xl border border-gray-200 bg-white p-8 shadow-sm">
+            <div
+              class="prose prose-lg max-w-none
+                prose-headings:text-gray-900
+                prose-p:text-gray-700 prose-p:leading-relaxed
+                prose-strong:text-gray-900
+                prose-code:bg-gray-100 prose-code:px-2 prose-code:py-1 prose-code:rounded prose-code:text-sm
+                prose-pre:bg-gray-900 prose-pre:text-gray-100
+                prose-blockquote:border-l-blue-500 prose-blockquote:bg-blue-50 prose-blockquote:p-4
+                prose-ul:text-gray-700 prose-ol:text-gray-700"
+            >
+              {@render children()}
+            </div>
 
-						<!-- Chapter Navigation -->
-						<footer class="mt-12 pt-8 border-t border-gray-200">
-							<div class="flex items-center justify-between">
-								{#if prevChapter}
-									<button
-										onclick={() => navigateToChapter(prevChapter)}
-										class="flex items-center gap-2 px-6 py-3 bg-gray-100 hover:bg-gray-200 rounded-xl transition-colors"
-									>
-										<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
-										</svg>
-										<div class="text-left">
-											<div class="text-xs text-gray-500">Previous</div>
-											<div class="font-medium">{prevChapter.title}</div>
-										</div>
-									</button>
-								{:else}
-									<div></div>
-								{/if}
+            <!-- Chapter Navigation -->
+            <footer class="mt-12 border-t border-gray-200 pt-8">
+              <div class="flex flex-wrap items-center justify-between gap-4">
+                {#if prevChapter}
+                  <button
+                    type="button"
+                    class="flex items-center gap-2 rounded-xl bg-gray-100 px-6 py-3 transition-colors hover:bg-gray-200"
+                    on:click={() => navigateToChapter(prevChapter)}
+                  >
+                    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
+                    </svg>
+                    <div class="text-left">
+                      <div class="text-xs text-gray-500">Previous</div>
+                      <div class="font-medium">{prevChapter.title}</div>
+                    </div>
+                  </button>
+                {:else}
+                  <span></span>
+                {/if}
 
-								{#if nextChapter && !nextChapter.disabled}
-									<button
-										onclick={() => navigateToChapter(nextChapter)}
-										class="flex items-center gap-2 px-6 py-3 bg-blue-500 hover:bg-blue-600 text-white rounded-xl transition-colors"
-									>
-										<div class="text-right">
-											<div class="text-xs text-blue-100">Next</div>
-											<div class="font-medium">{nextChapter.title}</div>
-										</div>
-										<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
-										</svg>
-									</button>
-								{/if}
-							</div>
-						</footer>
-					</article>
-				</main>
-			</div>
-		</div>
-	</div>
+                {#if nextChapter && !nextChapter.disabled}
+                  <button
+                    type="button"
+                    class="flex items-center gap-2 rounded-xl bg-blue-500 px-6 py-3 text-white transition-colors hover:bg-blue-600"
+                    on:click={() => navigateToChapter(nextChapter)}
+                  >
+                    <div class="text-right">
+                      <div class="text-xs text-blue-100">Next</div>
+                      <div class="font-medium">{nextChapter.title}</div>
+                    </div>
+                    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+                    </svg>
+                  </button>
+                {/if}
+              </div>
+            </footer>
+          </article>
+        </main>
+      </div>
+    </div>
+  </div>
 </div>

--- a/src/routes/book/chapter-1/+page.svelte
+++ b/src/routes/book/chapter-1/+page.svelte
@@ -8,6 +8,32 @@
 
   <p>Welcome to the foundation of building well-architected Svelte applications. In this chapter, we'll explore the core principles that separate good components from great ones, and learn how to think architecturally about your Svelte codebase.</p>
 
+  <div class="mb-10 rounded-2xl border border-blue-200 bg-blue-50 p-6 text-blue-900 shadow-inner">
+    <h2 class="text-lg font-semibold">How to use this chapter</h2>
+    <p class="mt-2 text-sm text-blue-900/80">
+      Spend a few focused minutes comparing the anti-pattern and the well-architected solution. Take notes on the prop surfaces,
+      where responsibilities live, and how each example could evolve as requirements change.
+    </p>
+    <ul class="mt-4 grid gap-2 text-sm text-blue-900/80 md:grid-cols-2">
+      <li class="flex items-start gap-2">
+        <span aria-hidden="true">🧠</span>
+        <span>Start by reading the philosophy—look for vocabulary you can use during design reviews.</span>
+      </li>
+      <li class="flex items-start gap-2">
+        <span aria-hidden="true">🧩</span>
+        <span>Toggle the live example to feel the difference between accidental complexity and intentional composition.</span>
+      </li>
+      <li class="flex items-start gap-2">
+        <span aria-hidden="true">🧪</span>
+        <span>Note the testing implications of each approach. How easy would it be to isolate logic or mock dependencies?</span>
+      </li>
+      <li class="flex items-start gap-2">
+        <span aria-hidden="true">🚀</span>
+        <span>Apply the takeaways to a component in your own codebase before moving to the next chapter.</span>
+      </li>
+    </ul>
+  </div>
+
   <h2>The Philosophy of Component Architecture</h2>
 
   <blockquote>


### PR DESCRIPTION
## Summary
- redesign the chapter 1 component comparison with richer guidance, architecture metrics, and async demo actions
- fix event bindings and shared UI components so the live examples respond correctly across the chapter
- refresh the book layout navigation and add a getting-started callout to improve the reading experience

## Testing
- `npm run check` *(fails: existing implicit any errors in analytics utilities and visualization components)*

------
https://chatgpt.com/codex/tasks/task_e_68c916e30a78832cb939d0f46fc5e67a