### PR TITLE
Add avatar fallback and improve book layout responsiveness

### DIFF
--- a/src/lib/components/book/examples/BadComponent.svelte
+++ b/src/lib/components/book/examples/BadComponent.svelte
@@ -52,7 +52,7 @@
 <div class="user-card" style={cardStyle}>
         {#if showAvatar}
                 <img
-                        src={userData?.avatar || '/default-avatar.png'}
+                        src={userData?.avatar || '/default-avatar.svg'}
                         alt={userData?.name}
                         style={`width: ${(avatarSize || 48)}px; height: ${(avatarSize || 48)}px;`}
                 />

--- a/src/lib/components/book/examples/ComponentComparison.svelte
+++ b/src/lib/components/book/examples/ComponentComparison.svelte
@@ -42,7 +42,7 @@ const cardStyle = \`
 // Template with too many conditional renders
 <div class="user-card" style={cardStyle}>
   {#if showAvatar}
-    <img src={userData?.avatar || '/default-avatar.png'}
+    <img src={userData?.avatar || '/default-avatar.svg'}
          alt={userData?.name}
          style={\`width: \${avatarSize || 48}px;\`} />
   {/if}

--- a/src/lib/layouts/BookLayout.svelte
+++ b/src/lib/layouts/BookLayout.svelte
@@ -124,9 +124,9 @@
         </nav>
       </header>
 
-      <div class="grid grid-cols-12 gap-8">
+      <div class="grid gap-8 lg:grid-cols-12">
         <!-- Table of Contents -->
-        <aside class="col-span-3">
+        <aside class="order-2 lg:order-1 lg:col-span-3">
           <div class="sticky top-8">
             <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
               <h3 class="mb-4 font-semibold text-gray-900">Table of Contents</h3>
@@ -168,7 +168,7 @@
         </aside>
 
         <!-- Main Content -->
-        <main class="col-span-9">
+        <main class="order-1 lg:order-2 lg:col-span-9">
           <article class="rounded-xl border border-gray-200 bg-white p-8 shadow-sm">
             <div
               class="prose prose-lg max-w-none

--- a/static/default-avatar.svg
+++ b/static/default-avatar.svg
@@ -1,0 +1,14 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Placeholder avatar</title>
+  <desc id="desc">A neutral avatar illustration used as a fallback image.</desc>
+  <defs>
+    <linearGradient id="avatarGradient" x1="10" y1="10" x2="70" y2="70" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#DBEAFE" />
+      <stop offset="1" stop-color="#C7D2FE" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="72" height="72" rx="36" fill="url(#avatarGradient)" />
+  <rect x="4" y="4" width="72" height="72" rx="36" stroke="#E5E7EB" stroke-width="2" />
+  <circle cx="40" cy="34" r="14" fill="#F9FAFB" />
+  <path d="M40 44C29.954 44 22 51.954 22 62H58C58 51.954 50.046 44 40 44Z" fill="#F3F4F6" />
+</svg>


### PR DESCRIPTION
## Summary
- add a static default avatar illustration to serve as a fallback for examples that previously referenced a missing asset
- update the bad architecture example and its accompanying code snippet to use the new fallback so the preview no longer shows a broken image
- tweak the book layout grid to stack on small screens, eliminating the horizontal overflow in the chapter view

## Testing
- npm run lint *(fails: existing Prettier formatting warnings throughout the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d3f479e4832c8161926dcd7f3088